### PR TITLE
Fixed Weltmeister editor on Windows

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -126,7 +126,7 @@ router.get('/lib/weltmeister/api/browse.php', function() {
       .then(function(dirs) {
         result.dirs = _.compact(dirs.map(function(dir) {
           if (dir.isDirectory) {
-            return dir.file;
+            return unixPath.join(request.query.dir, dir.file);
           }
         }));
       });


### PR DESCRIPTION
On Windows, path.join and path.relative automatically normalize paths to use backslash delimiters.  The Weltmeister editor expects server responses to be forward-slash-delimited.  This change always re-normalizes paths to use forward-slash delimiters.

P.S. Your code is beautiful!
