### PR TITLE
Throw useful error when dir not found

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -112,6 +112,9 @@ var browse = function() {
   var request = this.req;
   var response = this.res;
   fs.readdir(dir, function(err, files) {
+    if (err) {
+      throw err;
+    }
     var parent = path.dirname(request.query.dir);
     if (!request.query.dir) {
       parent = '';


### PR DESCRIPTION
I use this server frequently, but it crashes on many occasions, usually when I accidentally forget to put the correct `ig.config.levelPath` value, which causes WM to try looking for levels in a non-existent folder and then crash.

It will happen if you have levels in `lib/pong/levels` but forget to change the default path in the config.

The frustrating part is that the error message gives no indication whatsoever that it's a "folder not found" issue, or what is the relevant bad path. This patch fixes that.

Crashes that looked like this:

```
$ impact-dev-server
Listening on http://localhost:8080/ ...
/usr/local/lib/node_modules/impact-dev-server/lib/editor.js:122
    var gotDirs = Q.all(files.map(findDirs(dir)))
                              ^

TypeError: Cannot read property 'map' of undefined
```

Now look like this:

```
$ impact-dev-server
Listening on http://localhost:8080/ ...
/usr/local/lib/node_modules/impact-dev-server/lib/editor.js:116
      throw err;
      ^

---------------------------------------------------------
error: Error: ENOENT: no such file or directory, scandir 'lib/game/levels'
---------------------------------------------------------
stack:
```

Additionally, the crash could happen as easily as simply having not yet made the 'levels' folder, even if the path is indeed already correct.

This doesn't really fix the problem, just makes the problem easier to recognize.